### PR TITLE
Adds workflow to publish package to npm

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -1,0 +1,30 @@
+name: Publish npm package
+
+on:
+    release:
+        types: [published]
+
+jobs:
+    publish:
+        runs-on: ubuntu-latest
+
+        steps:
+            - name: Checkout code
+              uses: actions/checkout@v4
+
+            - name: Set up Node.js
+              uses: actions/setup-node@v4
+              with:
+                  node-version: '20' # Use your desired Node version
+                  registry-url: 'https://registry.npmjs.org/'
+
+            - name: Install dependencies
+              run: npm ci
+
+            - name: Build package
+              run: npm run build # Optional, if you have a build step
+
+            - name: Publish to npm
+              run: npm publish --access public # Use --access public for public packages
+              env:
+                  NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}


### PR DESCRIPTION
Sets up a GitHub Actions workflow that automatically publishes the npm package to the npm registry upon the creation of a new release.

This workflow streamlines the release process by automating the publishing steps, ensuring that the package is always up-to-date on npm.