### PR TITLE
Updates

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -14,11 +14,15 @@ src/**/*.d.ts
 **/*.js
 **/*.js.map
 
-# But DO NOT ignore jest.config.js.
+# DO NOT ignore jest.config.js.
 !jest.config.js
 
-# But DO NOT ignore eslint.config.js, needed by ESLint v9+.
+# DO NOT ignore eslint.config.js, needed by ESLint v9+.
 !eslint.config.js
+
+# DO NOT ignore test fixture src files.
+!test-cjs.js
+!esm-smoke.js
 
 # ANTLR4 output directory where all output is generated to.
 gen-output

--- a/README.md
+++ b/README.md
@@ -13,6 +13,13 @@ YINI is a simple, human-friendly configuration format inspired by INI and JSON.
 
 ---
 
+## 💡 Why YINI?
+- Easy to read and write — minimal syntax, maximum clarity.
+- Supports nested sections, strict/lenient modes, and all major data types.
+- A perfect alternative to messy JSON, legacy INI, or complex YAML.
+- Built for both JavaScript and TypeScript.
+- Human-friendly, machine-friendly, and ready for modern projects.
+  
 ## ✨ Features
 - Simple syntax (supports both strict and lenient modes).
 - Familiar config file style (inspired by INI, YAML, TOML).

--- a/README.md
+++ b/README.md
@@ -54,13 +54,25 @@ pnpm add yini-parser
 
 ## Usage
 
-> Only import the main class:
->
-> ```ts
-> import YINI from 'yini-parser';
-> ```
+### Node.js (CommonJS)
+```js
+const YINI = require('yini-parser');
+// If you get undefined, try:
+const YINI = require('yini-parser').default;
 
-### Example:
+// Parse from string.
+const config = YINI.parse(`
+    ^ App
+    title = 'My App Title'
+    items = 25
+    isDarkTheme = true
+`);
+
+// Parse from file.
+const configFromFile = YINI.parseFile('./config.yini');
+```
+
+### TypeScript (with `"esModuleInterop": true`)
 ```ts
 import YINI from 'yini-parser';
 

--- a/README.md
+++ b/README.md
@@ -55,6 +55,7 @@ pnpm add yini-parser
 ## Usage
 
 ### Node.js (CommonJS)
+**Note:** Only a default export (YINI) is provided. Named imports are not supported.
 ```js
 const YINI = require('yini-parser');
 // If you get undefined, try:
@@ -133,6 +134,79 @@ Returns a JavaScript object representing the parsed YINI configuration file.
 }
 ```
 
+---
+---
+
+### Bigger Example
+
+```js
+const YINI = require('yini-parser'); // Or: import YINI from 'yini-parser';
+
+const config = YINI.parse(`
+    /*
+        This is a multi-line block comment.
+    */
+
+    @yini
+
+    ^ App
+    name = "Nested Example"
+    version = "1.0.0"
+    debug = OFF  // This is a comment.
+
+        # Database settings.
+        ^^ Database
+        host = "db.example.com"
+        port = 3306
+        user = "appuser"
+        --password = "dbpassword"  # Disabled line due to --.
+        //password = "dbpassword"  # Not sure yet about this pw.
+        password = "dbpassword"  # Keep this secret.
+
+            // Commenting with slashes works too.
+            ^^^ Pool
+            min = 2
+            max = 10
+            idleTimeout = 300
+
+        /* Block comment on a single line. */
+        ^^ Logging
+        level = "info"
+        logToFile = ON # This is a comment.
+        filePath = "./logs/app.log"
+    
+    /END
+`);
+
+console.log(config);
+```
+
+#### Output:
+```js
+{
+    "App": {
+        "name": "Nested Example",
+        "version": "1.0.0",
+        "debug": false,
+        "Database": {
+            "host": "db.example.com",
+            "port": 3306,
+            "user": "appuser",
+            "password": "dbpassword",
+            "Pool": {
+                "min": 2,
+                "max": 10,
+                "idleTimeout": 300
+            }
+        },
+        "Logging": {
+            "level": "info",
+            "logToFile": true,
+            "filePath": "./logs/app.log"
+        }
+    }
+}
+```
 ---
 
 ## 📚 Documentation

--- a/package.json
+++ b/package.json
@@ -49,6 +49,7 @@
         "test:smoke:debug": "cross-env npm run test:smoke -- --isDebug=1",
         "test:unit:debug": "cross-env npm run test:unit -- --isDebug=1",
         "test:integr:debug": "cross-env npm run test:integr -- --isDebug=1",
+        "test:esm": "node ./tests/fixtures/test-src-files/esm-smoke.js",
         "ci:test": "cross-env NODE_ENV=test APP_ENV=ci jest --verbose --runInBand",
         "ci:test:smoke": "cross-env NODE_ENV=test APP_ENV=ci jest tests/smoke --verbose --runInBand",
         "tsc": "npx tsc -p ./tsconfig.json",

--- a/package.json
+++ b/package.json
@@ -1,16 +1,23 @@
 {
     "name": "yini-parser",
     "version": "1.0.0-alpha.4",
-    "description": "YINI parser for JavaScript/TypeScript, an INI-inspired configuration format, meant to be readable, and easy to use.",
+    "description": "Simple and flexible config parser for Node.js. YINI: an enhanced, readable alternative to JSON, INI, and YAML—built for modern JavaScript and TypeScript projects.",
     "keywords": [
-        "read",
         "yini",
+        "yini-parser",
         "config",
+        "config-file",
+        "configuration",
+        "settings",
         "ini",
+        "ini-parser",
+        "json-alternative",
+        "yaml-alternative",
         "parser",
-        "file",
         "parse",
-        "configuration"
+        "read",
+        "nodejs",
+        "javascript"
     ],
     "homepage": "https://m4se.com/yini-lang.org/",
     "license": "Apache-2.0",

--- a/src/utils/system.ts
+++ b/src/utils/system.ts
@@ -13,9 +13,14 @@ export const devPrint = (str: any = '') => {
     isDev() && !isTestEnv() && console.log('DEV: ' + str)
 }
 
+export const toPrettyJSON = (obj: any): string => {
+    const str = JSON.stringify(obj, null, 4)
+    return str
+}
+
 export const printObject = (obj: any) => {
     if (isProdEnv() || (isTestEnv() && !isDebug())) return
 
-    const str = JSON.stringify(obj, null, 4)
+    const str = toPrettyJSON(obj)
     console.log(str)
 }

--- a/tests/fixtures/test-src-files/esm-smoke.js
+++ b/tests/fixtures/test-src-files/esm-smoke.js
@@ -1,0 +1,18 @@
+const { spawnSync } = require('child_process')
+const path = require('path')
+
+const result = spawnSync(
+    process.execPath,
+    [
+        // Use --experimental-vm-modules if your Node version is <18 and you hit issues (sometimes not needed for 18+)
+        // '--experimental-vm-modules',
+        path.join(__dirname, 'test-esm.mjs'),
+    ],
+    { stdio: 'inherit' },
+)
+
+if (result.status !== 0) {
+    throw new Error('ESM smoke test failed!')
+} else {
+    console.log('ESM smoke test succeeded!')
+}

--- a/tests/fixtures/test-src-files/test-cjs.js
+++ b/tests/fixtures/test-src-files/test-cjs.js
@@ -1,0 +1,16 @@
+/**
+ * This file MUST be pure valid CommonJS.
+ */
+
+// NOTE: (!) Importat below is with require!
+const yini = require('../../../dist/cjs/index.js')
+
+// Test if has default export.
+function hasDefaultInCommonJS() {
+    const result = yini && yini.default ? true : false
+
+    console.log('CJS:', typeof yini, 'Has default: ', result)
+    return result
+}
+
+module.exports = { hasDefaultInCommonJS }

--- a/tests/fixtures/test-src-files/test-esm.mjs
+++ b/tests/fixtures/test-src-files/test-esm.mjs
@@ -1,0 +1,27 @@
+/**
+ * This file MUST have file ending ".mjs"!
+ *
+ * Node.js needs .mjs extension to know this is a module.
+ */
+
+import yini from '../../../dist/esm/index.js'
+
+// Test if import works.
+export function doesImportWorkInESM() {
+    const result = !!yini
+    // const result = true
+
+    console.log('ESM:', typeof yini, 'Import works: ', result)
+    return result
+}
+
+// console.log('qqqqqqqqqq: ' + process.argv[1])
+// console.log('wwwwwwwwww: ' + `file://${process.argv[1]}`)
+
+// Run directly if launched as main.
+if (process.argv[1] && process.argv[1].endsWith('test-esm.mjs')) {
+    const ok = doesImportWorkInESM()
+    // Exit with 0 if true, 1 if false, so parent process (esm-smoke.js) can check
+    // if (process.argv[1] && import.meta.url.endsWith(process.argv[1])) {
+    process.exit(ok ? 0 : 1)
+}

--- a/tests/smoke/E-final-and-misc-smoke.test.ts
+++ b/tests/smoke/E-final-and-misc-smoke.test.ts
@@ -87,7 +87,7 @@ describe('Final, Miscellaneous & Complementary Smoke Tests:', () => {
             ^ App
             name = "Nested Example"
             version = "1.0.0"
-            debug = OFF  // False.
+            debug = OFF  // This is a comment.
 
                 # Database setttings.
                 ^^ Database
@@ -107,7 +107,7 @@ describe('Final, Miscellaneous & Complementary Smoke Tests:', () => {
                 /* Block comment on a single line. */
                 ^^ Logging
                 level = "info"
-                logToFile = ON
+                logToFile = ON # This is a comment.
                 filePath = "./logs/app.log"
             
             /END

--- a/tests/smoke/E-final-and-misc-smoke.test.ts
+++ b/tests/smoke/E-final-and-misc-smoke.test.ts
@@ -1,0 +1,185 @@
+/**
+ * Final & Miscellaneous Smoke Tests.
+ *
+ * Last round of smoke tests, including any "miscellaneous" cases that does not
+ * fit in earlier groups.
+ */
+
+import { execSync } from 'child_process'
+import YINI from '../../src'
+import { debugPrint, toPrettyJSON } from '../../src/utils/system'
+// @ts-ignore
+import * as testCJS from '../fixtures/test-src-files/test-cjs'
+
+/**
+ * Final & Miscellaneous Smoke Tests.
+ */
+describe('Final & Miscellaneous Smoke Tests:', () => {
+    beforeAll(() => {})
+
+    test('1. Parsing inline, in default lenient mode, with correct object.', () => {
+        // Arrange.
+        const validYini = `^ App
+            title = 'My App Title'
+            items = 25
+            isDarkTheme = true`
+
+        // Act.
+        const result = YINI.parse(validYini)
+        debugPrint(result)
+
+        // Assert.
+        const answer = {
+            App: {
+                title: 'My App Title',
+                items: 25,
+                isDarkTheme: true,
+            },
+        }
+        expect(toPrettyJSON(result)).toEqual(toPrettyJSON(answer))
+        expect(result.meta).toEqual(undefined)
+    })
+
+    test('2. Parsing inline, and returning with meta data, with correct object.', () => {
+        // Arrange.
+        const validYini = `
+            @yini
+
+            ^ General
+            title = 'My Prog Title'
+            items = 25
+            isDarkTheme = OFF
+
+            ^ Database
+            host = 'localhost'
+            port = 5432    
+        `
+        // Act.
+        const metaResult = YINI.parse(validYini, false, 'auto', true)
+        debugPrint(metaResult)
+
+        // Assert.
+        const answer = {
+            General: {
+                title: 'My Prog Title',
+                items: 25,
+                isDarkTheme: false,
+            },
+            Database: {
+                host: 'localhost',
+                port: 5432,
+            },
+        }
+        expect(toPrettyJSON(metaResult.result)).toEqual(toPrettyJSON(answer))
+        expect(metaResult.meta.strictMode).toEqual(false)
+        expect(metaResult.meta.hasTerminal).toEqual(false)
+    })
+
+    test('3. Parsing inline in strict mode + has all commenting styles, returning with meta data, should return correct object.', () => {
+        // Arrange.
+        const validYini = `
+            /*
+                This is a multi-line block comment.
+            */
+
+            @YINI
+
+            ^ App
+            name = "Nested Example"
+            version = "1.0.0"
+            debug = OFF  // False.
+
+                # Database setttings.
+                ^^ Database
+                host = "db.example.com"
+                port = 3306
+                user = "appuser"
+                --password = "dbpassword"  # Old, save for now.
+                //password = "dbpassword"  # Not sure yet about this pw.
+                password = "dbpassword"  # Keep this secret.
+
+                    // Commenting with slashes works too.
+                    ^^^ Pool
+                    min = 2
+                    max = 10
+                    idleTimeout = 300
+
+                /* Block comment on a single line. */
+                ^^ Logging
+                level = "info"
+                logToFile = ON
+                filePath = "./logs/app.log"
+            
+            /END
+        `
+        // Act.
+        const metaResult = YINI.parse(validYini, true, 'auto', true)
+        debugPrint(metaResult)
+
+        // Assert.
+        const answer = {
+            App: {
+                name: 'Nested Example',
+                version: '1.0.0',
+                debug: false,
+                Database: {
+                    host: 'db.example.com',
+                    port: 3306,
+                    user: 'appuser',
+                    password: 'dbpassword',
+                    Pool: {
+                        min: 2,
+                        max: 10,
+                        idleTimeout: 300,
+                    },
+                },
+                Logging: {
+                    level: 'info',
+                    logToFile: true,
+                    filePath: './logs/app.log',
+                },
+            },
+        }
+        expect(toPrettyJSON(metaResult.result)).toEqual(toPrettyJSON(answer))
+        expect(metaResult.meta.strictMode).toEqual(true)
+        expect(metaResult.meta.hasTerminal).toEqual(true)
+    })
+
+    test('4. Parsing inline, but should throw error due to bad use of #.', () => {
+        // Arrange.
+        const invalidYini = `^ App
+            title = 'My App Title'
+            items = 25 #This comment is invalid, missing a space!
+            isDarkTheme = true`
+
+        // Act & Assert.
+        expect(() => {
+            YINI.parse(invalidYini)
+            debugPrint(invalidYini)
+        }).toThrow()
+    })
+
+    //@todo
+    xtest('5. --todo-- Parsing file with correct object.', () => {
+        // TODO
+        // expect(toPrettyJSON(result)).toEqual(toPrettyJSON(answer))
+    })
+
+    //@todo
+    xtest('6. --todo-- Parsing file with correct object.', () => {
+        // TODO
+        // expect(toPrettyJSON(result)).toEqual(toPrettyJSON(answer))
+    })
+
+    test('10. Has Default in CommonJS (from "dist/cjs").', () => {
+        const hasDefault = testCJS.hasDefaultInCommonJS()
+
+        expect(hasDefault).toEqual(true)
+    })
+
+    test('11. Does import work in ESM (from "dist/esm").', () => {
+        execSync('node ./tests/fixtures/test-src-files/esm-smoke.js', {
+            stdio: 'inherit',
+        })
+    })
+})

--- a/tests/smoke/E-final-and-misc-smoke.test.ts
+++ b/tests/smoke/E-final-and-misc-smoke.test.ts
@@ -1,7 +1,7 @@
 /**
- * Final & Miscellaneous Smoke Tests.
+ * Final & Miscellaneous/Complementary Smoke Tests.
  *
- * Last round of smoke tests, including any "miscellaneous" cases that does not
+ * Last round of smoke tests, including any "miscellaneous" / "complementary" cases that does not
  * fit in earlier groups.
  */
 
@@ -12,9 +12,9 @@ import { debugPrint, toPrettyJSON } from '../../src/utils/system'
 import * as testCJS from '../fixtures/test-src-files/test-cjs'
 
 /**
- * Final & Miscellaneous Smoke Tests.
+ * Final, Miscellaneous & Complementary Smoke Tests.
  */
-describe('Final & Miscellaneous Smoke Tests:', () => {
+describe('Final, Miscellaneous & Complementary Smoke Tests:', () => {
     beforeAll(() => {})
 
     test('1. Parsing inline, in default lenient mode, with correct object.', () => {

--- a/tests/smoke/E-final-and-misc-smoke.test.ts
+++ b/tests/smoke/E-final-and-misc-smoke.test.ts
@@ -174,9 +174,8 @@ describe('Final, Miscellaneous & Complementary Smoke Tests:', () => {
 
     // Skipping dual build for cjs and esm for now
     xtest('10. Has Default in CommonJS (from "dist/cjs").', () => {
-        const hasDefault = testCJS.hasDefaultInCommonJS()
-
-        expect(hasDefault).toEqual(true)
+        // const hasDefault = testCJS.hasDefaultInCommonJS()
+        // expect(hasDefault).toEqual(true)
     })
 
     // Skipping dual build for cjs and esm for now

--- a/tests/smoke/E-final-and-misc-smoke.test.ts
+++ b/tests/smoke/E-final-and-misc-smoke.test.ts
@@ -171,13 +171,15 @@ describe('Final, Miscellaneous & Complementary Smoke Tests:', () => {
         // expect(toPrettyJSON(result)).toEqual(toPrettyJSON(answer))
     })
 
-    test('10. Has Default in CommonJS (from "dist/cjs").', () => {
+    // Skipping dual build for cjs and esm for now
+    xtest('10. Has Default in CommonJS (from "dist/cjs").', () => {
         const hasDefault = testCJS.hasDefaultInCommonJS()
 
         expect(hasDefault).toEqual(true)
     })
 
-    test('11. Does import work in ESM (from "dist/esm").', () => {
+    // Skipping dual build for cjs and esm for now
+    xtest('11. Does import work in ESM (from "dist/esm").', () => {
         execSync('node ./tests/fixtures/test-src-files/esm-smoke.js', {
             stdio: 'inherit',
         })

--- a/tests/smoke/E-final-and-misc-smoke.test.ts
+++ b/tests/smoke/E-final-and-misc-smoke.test.ts
@@ -8,8 +8,9 @@
 import { execSync } from 'child_process'
 import YINI from '../../src'
 import { debugPrint, toPrettyJSON } from '../../src/utils/system'
+
 // @ts-ignore
-import * as testCJS from '../fixtures/test-src-files/test-cjs'
+// import * as testCJS from '../fixtures/test-src-files/test-cjs'
 
 /**
  * Final, Miscellaneous & Complementary Smoke Tests.


### PR DESCRIPTION
(Tried dual build esm and cjs, but skipping it for now.)

Adds nested YINI example and updates README instructions.

The changes introduce a more complex, nested YINI configuration example to the README.md file, demonstrating the parser's capabilities with nested sections, comments, and boolean values. It also updates the CommonJS usage instructions and adds TypeScript example.