### PR TITLE
Update/align with YINI Specification v1.0.0-RC.5

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,11 +1,15 @@
 # CHANGELOG
 
-## 1.4.3 + UPDATES - 2026 Apr xxx
+## 1.5.0 - 2026 Apr
+- **Updated:** Parser behavior aligned with YINI Specification `v1.0.0-RC.5`.
+- **Changed:** In strict mode, YINI documents must now end with the document terminator `/END`.
+- **Changed:** Strict mode now requires exactly one explicit top-level section.
+- **Updated:** Section header parsing now reflects the latest horizontal whitespace (`HSPACE`) rules from the specification.
 - **Improved:** Refined how members outside explicit sections are handled in lenient mode, and added stricter checks for top-level structure in strict mode.
-- **Added:** By default, strict mode requires exactly one explicit top-level section.
 - **Improved:** Clarified and tightened how empty values and explicit `null` are handled in lenient and strict mode.
 - **Improved:** Fixed `throwOnError` option detection, clarified the related documentation, and cleaned up public parameter names.
 - **Fixed:** Made `throwOnError` work consistently together with the selected fail level.
+- **Updated:** Synced to the latest lexer and parser grammar files from the Specification Package `v1.0.0-RC.5`, with cleaned up and refined grammar files for better consistency and maintainability.
 - **Added:** Expanded validation and tests for section headers, including shorthand markers, backticked names, and invalid dotted section names.
 - **Expanded:** Improved integration and smoke test coverage for error recovery, throw behavior, null handling, fixture parsing, and section/header edge cases.
 - **Updated:** Added and validated a new large smoke/golden fixture:

--- a/Makefile
+++ b/Makefile
@@ -1,6 +1,6 @@
 
-PARSER_FILE=./grammar/v1.0.0-rc.4xx/YiniParser.g4
-LEXER_FILE=./grammar/v1.0.0-rc.4xx/YiniLexer.g4
+PARSER_FILE=./grammar/v1.0.0-rc.5/YiniParser.g4
+LEXER_FILE=./grammar/v1.0.0-rc.5/YiniLexer.g4
 
 ANTLR_JAR=./libs/antlr4/antlr-4.13.2-complete.jar
 

--- a/README.md
+++ b/README.md
@@ -1,11 +1,11 @@
 # yini-parser
-> **Readable configuration for Node.js and TypeScript — without YAML foot-guns or JSON noise.**  
+> **Readable configuration for Node.js and TypeScript/JavaScript — without YAML footguns or JSON noise.**  
 
-The official TypeScript / Node.js parser for **YINI** (by the YINI-lang project) — a human-friendly configuration format with real structure, nested sections, comments, and predictable parsing.
+The official TypeScript / Node.js parser for **YINI** (by the YINI-lang project) — a human-friendly configuration format with clear structure, nested sections, comments, and predictable parsing.
 
 YINI is designed for applications, tools, and services that need configuration that stays readable for humans without becoming vague, fragile, or hard to maintain.  
 
-[![npm version](https://img.shields.io/npm/v/yini-parser.svg)](https://www.npmjs.com/package/yini-parser) [![All Test Suites](https://github.com/YINI-lang/yini-parser-typescript/actions/workflows/run-all-tests.yml/badge.svg)](https://github.com/YINI-lang/yini-parser-typescript/actions/workflows/run-all-tests.yml) [![All Regression Tests](https://github.com/YINI-lang/yini-parser-typescript/actions/workflows/run-regression-tests.yml/badge.svg)](https://github.com/YINI-lang/yini-parser-typescript/actions/workflows/run-regression-tests.yml) [![Grammar Drift Check](https://github.com/YINI-lang/yini-parser-typescript/actions/workflows/run-grammar-drift-check.yml/badge.svg)](https://github.com/YINI-lang/yini-parser-typescript/actions/workflows/run-grammar-drift-check.yml) [![npm downloads](https://img.shields.io/npm/dm/yini-parser)](https://www.npmjs.com/package/yini-parser)
+[![npm version](https://img.shields.io/npm/v/yini-parser.svg)](https://www.npmjs.com/package/yini-parser) [![TypeScript](https://img.shields.io/badge/TypeScript-5.x-3178C6?logo=typescript&logoColor=white)](https://www.typescriptlang.org/) [![All Test Suites](https://github.com/YINI-lang/yini-parser-typescript/actions/workflows/run-all-tests.yml/badge.svg)](https://github.com/YINI-lang/yini-parser-typescript/actions/workflows/run-all-tests.yml) [![All Regression Tests](https://github.com/YINI-lang/yini-parser-typescript/actions/workflows/run-regression-tests.yml/badge.svg)](https://github.com/YINI-lang/yini-parser-typescript/actions/workflows/run-regression-tests.yml) [![Grammar Drift Check](https://github.com/YINI-lang/yini-parser-typescript/actions/workflows/run-grammar-drift-check.yml/badge.svg)](https://github.com/YINI-lang/yini-parser-typescript/actions/workflows/run-grammar-drift-check.yml) [![npm downloads](https://img.shields.io/npm/dm/yini-parser)](https://www.npmjs.com/package/yini-parser)  
 
 ## Quick Start
 
@@ -36,18 +36,18 @@ console.log(config.App.Features.caching)  // true
 ## 🙋‍♀️ Why try YINI?
 
 - **Readable by humans** — Less noisy than JSON, less fragile than indentation-driven formats.
-- **Structured enough for real configuration** — Sections, nested sections, lists, objects, booleans, and null.
+- **Structured for real-world configuration** — Sections, nested sections, lists, objects, booleans, and null.
 - **Predictable parsing** — Explicit syntax with clear rules.
 - **Easy to use from TypeScript/Node.js** — Parse from strings or files in a few lines.
   
 ---
 
 ## What YINI looks like in practice
-> A basic YINI configuration example, showing a section, nested section, comments:  
+> A basic YINI configuration example, showing a section, a nested section, and comments:  
 ![YINI Config Example](./samples/basic.yini.png)
 Source: [basic.yini](./samples/basic.yini)
 
-- ▶️ Link to [Demo Apps](https://github.com/YINI-lang/yini-demo-apps/tree/main) with complete basic usage.
+- ▶️ [Demo Apps](https://github.com/YINI-lang/yini-demo-apps/tree/main) with complete usage examples.
 
 ---
 
@@ -55,7 +55,7 @@ Source: [basic.yini](./samples/basic.yini)
 - **Indentation-independent structure:** Spaces and tabs never change meaning, so files can be reformatted without changing structure.
 - **Explicit nesting:** Hierarchy is defined with section markers like `^`, `^^`, and `^^^`, making large configurations easier to scan and refactor.
 - **Multiple data types:** Supports booleans (`true` / `false`, `yes` / `no`, etc.), numbers, lists, and inline objects, with explicit string syntax.
-- **Comment support:** YINI supports multiple comment styles (`#`, `//`, `/* ... */`, and `;`), making it easier to document configuration directly in the file.
+- **Comment support:** YINI supports multiple comment styles (`#`, `//`, `/* ... */`, and `;`), making it easy to document configuration directly in the file.
 - **Predictable parsing:** Clear rules with optional strict and lenient modes for different use cases.
 
 ---
@@ -141,7 +141,7 @@ Source: [config.yini](./samples/config.yini)
 
 ## 🧪 Testing and Stability
 
-This parser is continuously validated through comprehensive regression and smoke tests, ensuring deterministic parsing behavior across default, strict, and metadata-enabled modes.
+This parser is validated through regression and smoke tests to help ensure stable, predictable parsing across default, strict, and metadata-enabled modes.
 
 ---
 
@@ -164,7 +164,7 @@ This parser is continuously validated through comprehensive regression and smoke
 ---
 
 ## 🤝 Contributing
-We welcome feedback, bug reports, feature requests, and code contributions!
+Feedback, bug reports, feature requests, and code contributions are welcome.
 - [Open an Issue](https://github.com/YINI-lang/yini-parser-typescript/issues)
 - [Start a Discussion](https://github.com/YINI-lang/yini-parser-typescript/discussions)
   
@@ -177,9 +177,9 @@ If this library is useful to you, a GitHub star helps more people discover the p
 ---
 
 ## License
-This project is licensed under the Apache-2.0 license — see the [LICENSE](./LICENSE) file for details.
+This project is licensed under the Apache License 2.0 — see the [LICENSE](./LICENSE) file for details.
 
-In this project on GitHub, the `libs` directory contains third party software and each is licensed under its own license which is described in its own license file under the respective directory under `libs`.
+In this project on GitHub, the `libs` directory contains third-party software and each is licensed under its own license, described in its own license file under the respective directory under `libs`.
 
 ---
 

--- a/grammar/v1.0.0-rc.4/YiniLexer.g4
+++ b/grammar/v1.0.0-rc.4/YiniLexer.g4
@@ -10,7 +10,7 @@
 /* 
   This LEXER grammar aims to follow, as closely as possible (*),
   the YINI format specification version:
-  1.2.0-rc.1x - 2026 Apr.
+  1.2.0-rc.1 - 2026 Mar.
 
   *) NOTE: Some rules are intentionally more permissive than the specification
   requires. This relaxation allows the host parser to detect syntax errors
@@ -47,13 +47,8 @@ DEPRECATED_TOKEN options {
 
 fragment EBD: ('0' | '1') ('0' | '1') ('0' | '1');
 
-fragment HSPACE : [ \t];
-
-// SECTION_HEAD: SECTION_MARKER HSPACE* WS* IDENT NL+;
-SECTION_HEAD
-  // : SECTION_MARKER HSPACE+ SECTION_NAME_PART NL+ // Requires hor-WS between marker and name.
-  : SECTION_MARKER HSPACE* SECTION_NAME_PART NL+   // Does NOT require hor-WS between marker and name.
-  ;
+//SECTION_HEAD: [ \t]* SECTION_MARKER [ \t]* WS* IDENT NL+;
+SECTION_HEAD: SECTION_MARKER [ \t]* WS* IDENT NL+;
 
 // Section markers: '^', '<', '§'.
 // – Up to six repeated markers are allowed (the parser must enforce the ≤ 6 rule).
@@ -76,7 +71,7 @@ fragment SECTION_MARKER_BASIC_REPEAT
 // Shorthand: a single marker followed by a positive integer (1 or larger).
 // Examples: ^7, <12, §100
 fragment SECTION_MARKER_SHORTHAND
-    : (CARET | LT | SS) [1-9] DIGIT* HSPACE
+    : (CARET | LT | SS) [1-9] DIGIT*
     ;
 
 fragment SECTION_MARKER_INVALID
@@ -135,47 +130,23 @@ NUMBER:
 		| HEX_INTEGER
 	);
 
-// KEY: IDENT;
-KEY
-  : SECTION_NAME_PART
-  | IDENT_INVALID
-  ;
+KEY: IDENT;
 
-// fragment IDENT
-//   : IDENT_SIMPLE
-// 	| IDENT_BACKTICKED
-// 	| IDENT_INVALID;
-fragment SECTION_NAME_PART
-  : IDENT_SIMPLE_LX
-  | IDENT_BACKTICKED
-  ;
+// NOTE: Intentionally allowing `.` even though the spec says simple
+// identifiers must not contain periods. Validation of illegal `.` is
+// deferred to the parser so the error can be reported there with a
+// more user-friendly message.
+IDENT: ('a' ..'z' | 'A' ..'Z' | '_') (
+		'a' ..'z'
+		| 'A' ..'Z'
+		| '0' ..'9'
+		| '_' | '.' // NOTE: Allowing . on purpose!
 
-// fragment DOTTED_COMPOUND_NAME
-//   : (IDENT_SIMPLE | IDENT_BACKTICKED) ('.' (IDENT_SIMPLE | IDENT_BACKTICKED))+
-//   ;
+	)*
+	| IDENT_BACKTICKED
+	| IDENT_INVALID;
 
-fragment IDENT_SIMPLE_START : [a-zA-Z_];
-fragment IDENT_SIMPLE_CHAR  : [a-zA-Z0-9_];
-
-// fragment IDENT_SIMPLE       : IDENT_SIMPLE_START IDENT_SIMPLE_CHAR*;
-
-// NOTE: This lexer rule is intentionally relaxed to allow `.` as well.
-// This makes it possible for the parser (or later validation step) to detect
-// dotted compound names and report a more user-friendly error message, even
-// though such names are invalid in the YINI specification.
-//
-// IMPORTANT: The parser/validator must still check identifiers for illegal
-// characters and reject invalid dotted names accordingly.
-//
-// Examples of invalid dotted compound names:
-//     key.two
-//     main.`illegal key`
-//     another.key.2
-//     `yet another`.illegal.key
-fragment IDENT_SIMPLE_LX       : IDENT_SIMPLE_START (IDENT_SIMPLE_CHAR | '.')*;
-
-// IDENT_BACKTICKED: '`' ~[\u0000-\u001F`]* '`'; // No newlines, tabs, or C0 controls.
-fragment IDENT_BACKTICKED: '`' ~[\u0000-\u001F`]* '`'; // No newlines, tabs, or C0 controls.
+IDENT_BACKTICKED: '`' ~[\u0000-\u001F`]* '`'; // No newlines, tabs, or C0 controls.
 
 // Illegal prefix characters and characters inside strings are deferred to the
 // parser, which gives more control and enables better user feedback (e.g.,
@@ -256,7 +227,7 @@ fragment SIGN: ('+' | '-');
 NL: ( WS* COMMENT* SINGLE_NL COMMENT*);
 SINGLE_NL: ('\r' '\n'? | '\n');
 
-WS: HSPACE+ -> skip;
+WS: [ \t]+ -> skip;
 
 /*
  BLOCK_COMMENT:
@@ -278,14 +249,14 @@ fragment DISABLE_LINE_MARKER: '--';
  */
 //LINE_COMMENT: ((DISABLE_LINE|';') ~[\r\n]*) -> skip;
 LINE_COMMENT
-  : {this.atLineStart()}? HSPACE* (DISABLE_LINE_MARKER | SEMICOLON) ~[\r\n]* -> skip
+  : {this.atLineStart()}? [ \t]* (DISABLE_LINE_MARKER | SEMICOLON) ~[\r\n]* -> skip
   ;
 
 /*
  INLINE_COMMENT: 
  Remains in input, but hidden (doesn't interfere with parsing).
  */
-INLINE_COMMENT: ('//' | '#' HSPACE+) ~[\r\n]* -> skip;
+INLINE_COMMENT: ('//' | '#' [ \t]+) ~[\r\n]* -> skip;
 
 IDENT_INVALID
     : [0-9][a-zA-Z0-9_]*

--- a/grammar/v1.0.0-rc.4/YiniParser.g4
+++ b/grammar/v1.0.0-rc.4/YiniParser.g4
@@ -9,13 +9,12 @@
 
 /* 
   This PARSER grammar aims to follow, as closely as possible (*),
-  the latest released version of the YINI format specification 1.0.0.
-  Version:
-  1.2.0-rc.1x - 2026 Apr.
+  the YINI format specification version:
+  1.2.0-rc.1 - 2026 Mar.
 
   *) NOTE: Some rules are intentionally more permissive than the specification
   requires. This relaxation allows the host parser to detect syntax errors
-  easier and provide clearer, more meaningful error messages. In the end, it is
+  esier and provide clearer, more meaningful error messages. In the end, it is
   the responsibility of the implementing parser to fully enforce all rules of
   the YINI specification.
 
@@ -44,34 +43,26 @@ yini
   : prolog? stmt* terminal_stmt? EOF
   ;
 
-/* ------------------------------------------------------------------
- * Prolog / terminal
- * ------------------------------------------------------------------ */
+/* -------- Prolog / terminal_stmt -------- */
 
 prolog
-  : SHEBANG eol*
-  | eol+
+  : SHEBANG eol*       // shebang present
+  | eol+               // or at least one blank/comment line
   ;
 
 terminal_stmt
-  : TERMINAL_TOKEN eol*
+  //: TERMINAL_TOKEN (eol | INLINE_COMMENT? NL*) // '/END' line, allow trailing comments/blank
+  : TERMINAL_TOKEN ( eol | INLINE_COMMENT )? NL*
   ;
 
-/* ------------------------------------------------------------------
- * Statements (flat)
- * ------------------------------------------------------------------ */
+/* -------- Statements (flat) -------- */
 
 stmt
-  : eol             // BlankOrComment
-  | SECTION_HEAD    // SectionHeader
-  | invalid_section_stmt
-  | assignment      // key = value
+  : eol				// BlankOrComment
+  | SECTION_HEAD	// SectionHeader
+  | assignment		// key = value
   | meta_stmt       // Note: The implementing parser is responsible for enforcing YINI marker constraints.
   | bad_member      // BadMember
-  ;
-
-invalid_section_stmt
-  : INVALID_SECTION_HEAD
   ;
 
 // Any tokens and statements starting with an AT (@).
@@ -88,7 +79,7 @@ meta_stmt
  */
 directive
   : YINI_TOKEN eol
-  | INCLUDE_TOKEN string_literal? eol
+  | INCLUDE_TOKEN WS* string_literal? eol
   ;
 
 /*
@@ -96,7 +87,7 @@ directive
  * by including or transforming content before/while parsing.
  */
 // pre_processing_command
-//   : INCLUDE_TOKEN string_literal? eol
+//   : INCLUDE_TOKEN WS* string_literal? eol
 //   ;
 
 /*
@@ -110,15 +101,13 @@ annotation
   : DEPRECATED_TOKEN eol
   ;
 
-/* A single physical "end-of-line" unit.
-   Use this everywhere instead of sprinkling NL* in statement rules. */
+/* A single physical "end-of-line" unit (blank or comment then NL).
+   Use this everywhere instead of sprinkling NL* / INLINE_COMMENT* */
 eol
-  : NL+
+  : INLINE_COMMENT? NL+
   ;
 
-/* ------------------------------------------------------------------
- * Members / assignments
- * ------------------------------------------------------------------ */
+/* -------- Members / assignments -------- */
 
 /* Assignment is always: KEY = value/literal */
 assignment
@@ -127,17 +116,13 @@ assignment
 
 /* KEY = value  (value may be empty in lenient-mode -> NULL by convention,
  * enforced and validated in host code, not here.)
- *
  * @note (!) KEY, EQ, and value MUST be on the same line!
  */
-member
-  : KEY EQ value? // Empty value is treated as NULL.
+member:
+  KEY WS? EQ WS? value? // Empty value is treated as NULL.
   ;
 
-/* ------------------------------------------------------------------
- * Values
- * ------------------------------------------------------------------ */
-
+/* -------- Values -------- */
 value
   : null_literal
   | string_literal
@@ -147,21 +132,21 @@ value
   | object_literal
   ;
 
-/* Object literal is defined with object members such as { key: value, ... }
- * with optional trailing comma and newlines tolerated.
+/* Object_literal is defined with object members such as { key: value, ... }
+ * with optional trailing comma and newlines tolerated 
  */
 object_literal
   : OC NL* object_members? NL* CC NL*
   | EMPTY_OBJECT NL*
   ;
 
-// Object members are one or more key:value pairs separated by commas.
+// A object_members is one or more key=value pairs separated by commas.
 object_members
   : object_member (COMMA NL* object_member)* COMMA?
   ;
 
 object_member
-  : KEY COLON NL* value
+  : KEY WS? COLON NL* value
   ;
 
 /* [ value, ... ] with optional trailing comma and newlines tolerated */
@@ -176,35 +161,15 @@ list_literal
 elements
   : value (NL* COMMA NL* value)* COMMA?
   ;
+  
 
-/* ------------------------------------------------------------------
- * Terminals forwarded from the lexer
- * ------------------------------------------------------------------ */
+/* -------- Terminals forwarded from the lexer -------- */
 
-number_literal
-  : NUMBER
-  ;
-
-null_literal
-  : NULL // NOTE: NULL is case-insensitive.
-  ;
-
-string_literal
-  : STRING string_concat*
-  ;
-
-string_concat
-  : NL* PLUS NL* STRING
-  ;
-
-boolean_literal
-  : BOOLEAN_TRUE
-  | BOOLEAN_FALSE // NOTE: Booleans are case-insensitive.
-  ;
-
-/* ------------------------------------------------------------------
- * Error helpers
- * ------------------------------------------------------------------ */
+number_literal   : NUMBER;
+null_literal     : NULL;							// NOTE: NULL is case-insensitive.
+string_literal   : STRING string_concat*;
+string_concat    : NL* PLUS NL* STRING;
+boolean_literal  : BOOLEAN_TRUE | BOOLEAN_FALSE;	// NOTE: Booleans are case-insensitive.
 
 bad_meta_text
   : META_INVALID
@@ -214,5 +179,5 @@ bad_meta_text
  * Keep a narrow error production, don't over-greedy-capture.
  */
 bad_member
-  : (REST | value)? EQ (value | REST) eol?
+  : WS? (REST | value)? WS? EQ (value | REST) eol?
   ;

--- a/grammar/v1.0.0-rc.5/YiniLexer.g4
+++ b/grammar/v1.0.0-rc.5/YiniLexer.g4
@@ -11,7 +11,7 @@
   This LEXER grammar aims to follow, as closely as possible (*),
   the latest released version of the YINI format specification 1.0.0.
   Version:
-  1.2.0-rc.1x - 2026 Apr.
+  1.2.0-rc.2 - 2026 Apr.
 
   *) NOTE: Some rules are intentionally more permissive than the specification
   requires. This relaxation allows the host parser to detect syntax errors

--- a/grammar/v1.0.0-rc.5/YiniParser.g4
+++ b/grammar/v1.0.0-rc.5/YiniParser.g4
@@ -9,12 +9,13 @@
 
 /* 
   This PARSER grammar aims to follow, as closely as possible (*),
-  the YINI format specification version:
-  1.2.0-rc.1x - 2026 Apr.
+  the latest released version of the YINI format specification 1.0.0.
+  Version:
+  1.2.0-rc.2 - 2026 Apr.
 
   *) NOTE: Some rules are intentionally more permissive than the specification
   requires. This relaxation allows the host parser to detect syntax errors
-  esier and provide clearer, more meaningful error messages. In the end, it is
+  easier and provide clearer, more meaningful error messages. In the end, it is
   the responsibility of the implementing parser to fully enforce all rules of
   the YINI specification.
 
@@ -43,26 +44,34 @@ yini
   : prolog? stmt* terminal_stmt? EOF
   ;
 
-/* -------- Prolog / terminal_stmt -------- */
+/* ------------------------------------------------------------------
+ * Prolog / terminal
+ * ------------------------------------------------------------------ */
 
 prolog
-  : SHEBANG eol*       // shebang present
-  | eol+               // or at least one blank/comment line
+  : SHEBANG eol*
+  | eol+
   ;
 
 terminal_stmt
-  //: TERMINAL_TOKEN (eol | INLINE_COMMENT? NL*) // '/END' line, allow trailing comments/blank
-  : TERMINAL_TOKEN ( eol | INLINE_COMMENT )? NL*
+  : TERMINAL_TOKEN eol*
   ;
 
-/* -------- Statements (flat) -------- */
+/* ------------------------------------------------------------------
+ * Statements (flat)
+ * ------------------------------------------------------------------ */
 
 stmt
-  : eol				// BlankOrComment
-  | SECTION_HEAD	// SectionHeader
-  | assignment		// key = value
+  : eol             // BlankOrComment
+  | SECTION_HEAD    // SectionHeader
+  | invalid_section_stmt
+  | assignment      // key = value
   | meta_stmt       // Note: The implementing parser is responsible for enforcing YINI marker constraints.
   | bad_member      // BadMember
+  ;
+
+invalid_section_stmt
+  : INVALID_SECTION_HEAD
   ;
 
 // Any tokens and statements starting with an AT (@).
@@ -79,7 +88,7 @@ meta_stmt
  */
 directive
   : YINI_TOKEN eol
-  | INCLUDE_TOKEN WS* string_literal? eol
+  | INCLUDE_TOKEN string_literal? eol
   ;
 
 /*
@@ -87,7 +96,7 @@ directive
  * by including or transforming content before/while parsing.
  */
 // pre_processing_command
-//   : INCLUDE_TOKEN WS* string_literal? eol
+//   : INCLUDE_TOKEN string_literal? eol
 //   ;
 
 /*
@@ -101,13 +110,15 @@ annotation
   : DEPRECATED_TOKEN eol
   ;
 
-/* A single physical "end-of-line" unit (blank or comment then NL).
-   Use this everywhere instead of sprinkling NL* / INLINE_COMMENT* */
+/* A single physical "end-of-line" unit.
+   Use this everywhere instead of sprinkling NL* in statement rules. */
 eol
-  : INLINE_COMMENT? NL+
+  : NL+
   ;
 
-/* -------- Members / assignments -------- */
+/* ------------------------------------------------------------------
+ * Members / assignments
+ * ------------------------------------------------------------------ */
 
 /* Assignment is always: KEY = value/literal */
 assignment
@@ -116,13 +127,17 @@ assignment
 
 /* KEY = value  (value may be empty in lenient-mode -> NULL by convention,
  * enforced and validated in host code, not here.)
+ *
  * @note (!) KEY, EQ, and value MUST be on the same line!
  */
-member:
-  KEY WS? EQ WS? value? // Empty value is treated as NULL.
+member
+  : KEY EQ value? // Empty value is treated as NULL.
   ;
 
-/* -------- Values -------- */
+/* ------------------------------------------------------------------
+ * Values
+ * ------------------------------------------------------------------ */
+
 value
   : null_literal
   | string_literal
@@ -132,21 +147,21 @@ value
   | object_literal
   ;
 
-/* Object_literal is defined with object members such as { key: value, ... }
- * with optional trailing comma and newlines tolerated 
+/* Object literal is defined with object members such as { key: value, ... }
+ * with optional trailing comma and newlines tolerated.
  */
 object_literal
   : OC NL* object_members? NL* CC NL*
   | EMPTY_OBJECT NL*
   ;
 
-// A object_members is one or more key=value pairs separated by commas.
+// Object members are one or more key:value pairs separated by commas.
 object_members
   : object_member (COMMA NL* object_member)* COMMA?
   ;
 
 object_member
-  : KEY WS? COLON NL* value
+  : KEY COLON NL* value
   ;
 
 /* [ value, ... ] with optional trailing comma and newlines tolerated */
@@ -161,15 +176,35 @@ list_literal
 elements
   : value (NL* COMMA NL* value)* COMMA?
   ;
-  
 
-/* -------- Terminals forwarded from the lexer -------- */
+/* ------------------------------------------------------------------
+ * Terminals forwarded from the lexer
+ * ------------------------------------------------------------------ */
 
-number_literal   : NUMBER;
-null_literal     : NULL;							// NOTE: NULL is case-insensitive.
-string_literal   : STRING string_concat*;
-string_concat    : NL* PLUS NL* STRING;
-boolean_literal  : BOOLEAN_TRUE | BOOLEAN_FALSE;	// NOTE: Booleans are case-insensitive.
+number_literal
+  : NUMBER
+  ;
+
+null_literal
+  : NULL // NOTE: NULL is case-insensitive.
+  ;
+
+string_literal
+  : STRING string_concat*
+  ;
+
+string_concat
+  : NL* PLUS NL* STRING
+  ;
+
+boolean_literal
+  : BOOLEAN_TRUE
+  | BOOLEAN_FALSE // NOTE: Booleans are case-insensitive.
+  ;
+
+/* ------------------------------------------------------------------
+ * Error helpers
+ * ------------------------------------------------------------------ */
 
 bad_meta_text
   : META_INVALID
@@ -179,5 +214,5 @@ bad_meta_text
  * Keep a narrow error production, don't over-greedy-capture.
  */
 bad_member
-  : WS? (REST | value)? WS? EQ (value | REST) eol?
+  : (REST | value)? EQ (value | REST) eol?
   ;

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
     "name": "yini-parser",
-    "version": "1.4.3",
+    "version": "1.5.0",
     "lockfileVersion": 3,
     "requires": true,
     "packages": {
         "": {
             "name": "yini-parser",
-            "version": "1.4.3",
+            "version": "1.5.0",
             "license": "Apache-2.0",
             "dependencies": {
                 "antlr4": "^4.13.2"

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
     "name": "yini-parser",
-    "version": "1.4.3",
+    "version": "1.5.0",
     "description": "TypeScript/JavaScript parser for YINI — a human-friendly config format that combines INI-style simplicity with real structure, nested sections, comments, and predictable parsing.",
     "keywords": [
         "yini",

--- a/src/grammar/generated/YiniLexer.ts
+++ b/src/grammar/generated/YiniLexer.ts
@@ -1,4 +1,4 @@
-// Generated from ./grammar/v1.0.0-rc.4xx/YiniLexer.g4 by ANTLR 4.13.2
+// Generated from ./grammar/v1.0.0-rc.5/YiniLexer.g4 by ANTLR 4.13.2
 // noinspection ES6UnusedImports,JSUnusedGlobalSymbols,JSUnusedLocalSymbols
 import {
 	ATN,

--- a/src/grammar/generated/YiniParser.ts
+++ b/src/grammar/generated/YiniParser.ts
@@ -1,4 +1,4 @@
-// Generated from ./grammar/v1.0.0-rc.4xx/YiniParser.g4 by ANTLR 4.13.2
+// Generated from ./grammar/v1.0.0-rc.5/YiniParser.g4 by ANTLR 4.13.2
 // noinspection ES6UnusedImports,JSUnusedGlobalSymbols,JSUnusedLocalSymbols
 
 import {

--- a/src/grammar/generated/YiniParserVisitor.ts
+++ b/src/grammar/generated/YiniParserVisitor.ts
@@ -1,4 +1,4 @@
-// Generated from ./grammar/v1.0.0-rc.4xx/YiniParser.g4 by ANTLR 4.13.2
+// Generated from ./grammar/v1.0.0-rc.5/YiniParser.g4 by ANTLR 4.13.2
 
 import {ParseTreeVisitor} from 'antlr4';
 


### PR DESCRIPTION
Bumps version to 1.5.0 and syncs grammar files with the latest specification. This updates strict mode to require a document terminator and exactly one top-level section, while refining horizontal whitespace rules for section headers.